### PR TITLE
expose apk_circuits stuff

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,10 @@ derivative = { version = "2", features = ["use_core"] }
 rand = { version = "0.8.4", features = ["getrandom"] }
 
 [dev-dependencies]
-ark-bls12-381 = { version = "0.4.0", features = ["curve"], default-features = false }
-ark-bls12-377 = { version = "0.4.0", features = ["curve"], default-features = false }
+ark-bls12-381 = { version = "0.4.0", features = [
+    "curve",
+], default-features = false }
+ark-bls12-377 = { version = "0.4.0", features = [
+    "curve",
+], default-features = false }
 ark-bw6-761 = { version = "0.4.0", default-features = false }

--- a/src/affine_gen.rs
+++ b/src/affine_gen.rs
@@ -2,11 +2,12 @@ use std::borrow::Borrow;
 use std::marker::PhantomData;
 
 use ark_ec::short_weierstrass::{Affine, SWCurveConfig};
-use ark_r1cs_std::alloc::{AllocationMode, AllocVar};
+use ark_r1cs_std::alloc::{AllocVar, AllocationMode};
 use ark_r1cs_std::boolean::Boolean;
+use ark_r1cs_std::eq::EqGadget;
 use ark_r1cs_std::fields::{FieldOpsBounds, FieldVar};
-use ark_r1cs_std::R1CSVar;
 use ark_r1cs_std::select::CondSelectGadget;
+use ark_r1cs_std::R1CSVar;
 use ark_relations::r1cs::{ConstraintSystemRef, Field, Namespace, SynthesisError};
 use derivative::Derivative;
 
@@ -14,10 +15,10 @@ use derivative::Derivative;
 #[derivative(Debug, Clone)]
 #[must_use]
 pub struct NonZeroAffineVarGeneric<P, F, CF>
-    where
-        P: SWCurveConfig,
-        CF: Field, // Constraint system field aka 'native'
-        F: FieldVar<P::BaseField, CF>, // Represents elements of P::BaseField in CF either as-is or using non-native arithmetic.
+where
+    P: SWCurveConfig,
+    CF: Field,                     // Constraint system field aka 'native'
+    F: FieldVar<P::BaseField, CF>, // Represents elements of P::BaseField in CF either as-is or using non-native arithmetic.
 {
     pub x: F,
     pub y: F,
@@ -28,40 +29,64 @@ pub struct NonZeroAffineVarGeneric<P, F, CF>
 }
 
 impl<P, F, CF> AllocVar<Affine<P>, CF> for NonZeroAffineVarGeneric<P, F, CF>
-    where
-        P: SWCurveConfig,
-        CF: Field,
-        F: FieldVar<P::BaseField, CF>,
+where
+    P: SWCurveConfig,
+    CF: Field,
+    F: FieldVar<P::BaseField, CF>,
 {
-    fn new_variable<T: Borrow<Affine<P>>>(cs: impl Into<Namespace<CF>>, f: impl FnOnce() -> Result<T, SynthesisError>, mode: AllocationMode) -> Result<Self, SynthesisError> {
+    fn new_variable<T: Borrow<Affine<P>>>(
+        cs: impl Into<Namespace<CF>>,
+        f: impl FnOnce() -> Result<T, SynthesisError>,
+        mode: AllocationMode,
+    ) -> Result<Self, SynthesisError> {
         let ns = cs.into();
         let cs = ns.cs();
         let point = f().map(|b| *b.borrow());
         let x = F::new_variable(ark_relations::ns!(cs, "x"), || point.map(|p| p.x), mode)?;
         let y = F::new_variable(ark_relations::ns!(cs, "y"), || point.map(|p| p.y), mode)?;
-        let point_var = NonZeroAffineVarGeneric { x, y, _p: PhantomData, _cf: PhantomData };
+        let point_var = NonZeroAffineVarGeneric {
+            x,
+            y,
+            _p: PhantomData,
+            _cf: PhantomData,
+        };
         Ok(point_var)
     }
 }
 
 impl<P, F, CF> CondSelectGadget<CF> for NonZeroAffineVarGeneric<P, F, CF>
-    where
-        P: SWCurveConfig,
-        CF: Field,
-        F: FieldVar<P::BaseField, CF>,
+where
+    P: SWCurveConfig,
+    CF: Field,
+    F: FieldVar<P::BaseField, CF>,
 {
-    fn conditionally_select(cond: &Boolean<CF>, true_value: &Self, false_value: &Self) -> Result<Self, SynthesisError> {
+    fn conditionally_select(
+        cond: &Boolean<CF>,
+        true_value: &Self,
+        false_value: &Self,
+    ) -> Result<Self, SynthesisError> {
         let x = cond.select(&true_value.x, &false_value.x)?;
         let y = cond.select(&true_value.y, &false_value.y)?;
         Ok(Self::new(x, y))
     }
 }
 
+impl<P, F, CF> EqGadget<CF> for NonZeroAffineVarGeneric<P, F, CF>
+where
+    P: SWCurveConfig,
+    CF: Field,
+    F: FieldVar<P::BaseField, CF>,
+{
+    fn is_eq(&self, other: &Self) -> Result<Boolean<CF>, SynthesisError> {
+        self.x.is_eq(&other.x)?.and(&self.y.is_eq(&other.y)?)
+    }
+}
+
 impl<P, F, CF> R1CSVar<CF> for NonZeroAffineVarGeneric<P, F, CF>
-    where
-        P: SWCurveConfig,
-        CF: Field,
-        F: FieldVar<P::BaseField, CF>,
+where
+    P: SWCurveConfig,
+    CF: Field,
+    F: FieldVar<P::BaseField, CF>,
 {
     type Value = Affine<P>;
 
@@ -75,17 +100,23 @@ impl<P, F, CF> R1CSVar<CF> for NonZeroAffineVarGeneric<P, F, CF>
 }
 
 impl<P, F, CF> NonZeroAffineVarGeneric<P, F, CF>
-    where
-        P: SWCurveConfig,
-        CF: Field,
-        F: FieldVar<P::BaseField, CF>,
+where
+    P: SWCurveConfig,
+    CF: Field,
+    F: FieldVar<P::BaseField, CF>,
 {
     pub fn new(x: F, y: F) -> Self {
-        Self { x, y, _p: Default::default(), _cf: Default::default() }
+        Self {
+            x,
+            y,
+            _p: Default::default(),
+            _cf: Default::default(),
+        }
     }
 
     pub fn add_unchecked(&self, other: &Self) -> Result<Self, SynthesisError>
-        where for<'a> &'a F: FieldOpsBounds<'a, P::BaseField, F>
+    where
+        for<'a> &'a F: FieldOpsBounds<'a, P::BaseField, F>,
     {
         let (x1, y1) = (&self.x, &self.y);
         let (x2, y2) = (&other.x, &other.y);
@@ -115,16 +146,28 @@ mod tests {
         let rng = &mut test_rng();
         let cs = ConstraintSystem::<ark_bw6_761::Fr>::new_ref();
         let n = 10;
-        let keys: Vec<ark_bls12_377::G1Affine> = (0..n).map(|_| ark_bls12_377::G1Affine::rand(rng)).collect();
+        let keys: Vec<ark_bls12_377::G1Affine> =
+            (0..n).map(|_| ark_bls12_377::G1Affine::rand(rng)).collect();
         let mut tracker = Tracker::new(&cs);
-        let mut key_vars = Vec::<NonZeroAffineVarGeneric<_, FpVar<ark_bw6_761::Fr>, _>>::new_witness(ns!(cs, "keys"), || Ok(keys.clone())).unwrap().into_iter();
+        let mut key_vars =
+            Vec::<NonZeroAffineVarGeneric<_, FpVar<ark_bw6_761::Fr>, _>>::new_witness(
+                ns!(cs, "keys"),
+                || Ok(keys.clone()),
+            )
+            .unwrap()
+            .into_iter();
         println!("allocating {} native points: {:?}", n, tracker.update(&cs));
         let mut sum = key_vars.next().unwrap();
         for key in key_vars {
             sum = sum.add_unchecked(&key).unwrap();
         }
         println!("summing {} native points: {:?}", n, tracker.update(&cs));
-        assert_eq!(sum.value().unwrap(), keys.iter().sum::<ark_bls12_377::G1Projective>().into_affine());
+        assert_eq!(
+            sum.value().unwrap(),
+            keys.iter()
+                .sum::<ark_bls12_377::G1Projective>()
+                .into_affine()
+        );
         assert!(cs.is_satisfied().unwrap());
     }
 
@@ -133,16 +176,31 @@ mod tests {
         let rng = &mut test_rng();
         let cs = ConstraintSystem::<ark_bls12_381::Fr>::new_ref();
         let n = 10;
-        let keys: Vec<ark_bls12_381::G1Affine> = (0..n).map(|_| ark_bls12_381::G1Affine::rand(rng)).collect();
+        let keys: Vec<ark_bls12_381::G1Affine> =
+            (0..n).map(|_| ark_bls12_381::G1Affine::rand(rng)).collect();
         let mut tracker = Tracker::new(&cs);
-        let mut key_vars = Vec::<NonZeroAffineVarGeneric<_, BlsInBls, _>>::new_witness(ns!(cs, "keys"), || Ok(keys.clone())).unwrap().into_iter();
-        println!("allocating {} emulated points: {:?}", n, tracker.update(&cs));
+        let mut key_vars =
+            Vec::<NonZeroAffineVarGeneric<_, BlsInBls, _>>::new_witness(ns!(cs, "keys"), || {
+                Ok(keys.clone())
+            })
+            .unwrap()
+            .into_iter();
+        println!(
+            "allocating {} emulated points: {:?}",
+            n,
+            tracker.update(&cs)
+        );
         let mut sum = key_vars.next().unwrap();
         for key in key_vars {
             sum = sum.add_unchecked(&key).unwrap();
         }
         println!("summing {} emulated points: {:?}", n, tracker.update(&cs));
-        assert_eq!(sum.value().unwrap(), keys.iter().sum::<ark_bls12_381::G1Projective>().into_affine());
+        assert_eq!(
+            sum.value().unwrap(),
+            keys.iter()
+                .sum::<ark_bls12_381::G1Projective>()
+                .into_affine()
+        );
         assert!(cs.is_satisfied().unwrap());
     }
 }

--- a/src/apk_circuits.rs
+++ b/src/apk_circuits.rs
@@ -3,10 +3,10 @@ use std::marker::PhantomData;
 use ark_ec::short_weierstrass::{Affine, SWCurveConfig};
 use ark_ff::{Field, PrimeField};
 use ark_r1cs_std::alloc::AllocVar;
-use ark_r1cs_std::fields::{FieldOpsBounds, FieldVar};
 use ark_r1cs_std::fields::fp::FpVar;
-use ark_r1cs_std::fields::nonnative::AllocatedNonNativeFieldVar;
 use ark_r1cs_std::fields::nonnative::params::OptimizationType;
+use ark_r1cs_std::fields::nonnative::AllocatedNonNativeFieldVar;
+use ark_r1cs_std::fields::{FieldOpsBounds, FieldVar};
 use ark_r1cs_std::select::CondSelectGadget;
 use ark_r1cs_std::ToBitsGadget;
 use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef};
@@ -24,31 +24,60 @@ pub struct ApkCircuit<P: SWCurveConfig, CF: Field, F: FieldVar<P::BaseField, CF>
     _f: PhantomData<F>,
 }
 
+impl<P: SWCurveConfig, CF: Field, F: FieldVar<P::BaseField, CF>> ApkCircuit<P, CF, F> {
+    pub fn new(keys: Vec<Affine<P>>, seed: Affine<P>, packed_bits: CF) -> Self {
+        Self {
+            keys,
+            seed,
+            packed_bits,
+            _f: PhantomData,
+        }
+    }
+}
+
 impl<P, CF, F> ConstraintSynthesizer<CF> for ApkCircuit<P, CF, F>
-    where P: SWCurveConfig,
-          CF: PrimeField,
-          F: FieldVar<P::BaseField, CF>,
-          for<'a> &'a F: FieldOpsBounds<'a, P::BaseField, F>,
+where
+    P: SWCurveConfig,
+    CF: PrimeField,
+    F: FieldVar<P::BaseField, CF>,
+    for<'a> &'a F: FieldOpsBounds<'a, P::BaseField, F>,
 {
     fn generate_constraints(self, cs: ConstraintSystemRef<CF>) -> ark_relations::r1cs::Result<()> {
-        let seed_const = NonZeroAffineVarGeneric::<P, F, CF>::new_constant(ark_relations::ns!(cs, "seed"), &self.seed)?;
-        let key_vars = Vec::<NonZeroAffineVarGeneric::<P, F, CF>>::new_input(ark_relations::ns!(cs, "keys"), || Ok(self.keys))?;
-        let packed_bits_var = FpVar::new_input(ark_relations::ns!(cs, "bitmask_packed"), || Ok(&self.packed_bits))?;
+        let seed_const = NonZeroAffineVarGeneric::<P, F, CF>::new_constant(
+            ark_relations::ns!(cs, "seed"),
+            &self.seed,
+        )?;
+        let key_vars = Vec::<NonZeroAffineVarGeneric<P, F, CF>>::new_input(
+            ark_relations::ns!(cs, "keys"),
+            || Ok(self.keys),
+        )?;
+        let packed_bits_var = FpVar::new_input(ark_relations::ns!(cs, "bitmask_packed"), || {
+            Ok(&self.packed_bits)
+        })?;
         let bit_vars = packed_bits_var.to_bits_le()?;
 
         let mut curr_sum = seed_const;
         for (b, key) in bit_vars.iter().zip(key_vars) {
             let next_sum = curr_sum.add_unchecked(&key)?;
-            curr_sum = NonZeroAffineVarGeneric::<P, F, CF>::conditionally_select(b, &next_sum, &curr_sum)?;
+            curr_sum =
+                NonZeroAffineVarGeneric::<P, F, CF>::conditionally_select(b, &next_sum, &curr_sum)?;
         }
         Ok(())
     }
 }
 
-pub fn keys_to_limbs<F: PrimeField, CF: PrimeField, P: SWCurveConfig<BaseField=F>>(keys: &[Affine<P>]) -> Vec<CF> {
+pub fn keys_to_limbs<F: PrimeField, CF: PrimeField, P: SWCurveConfig<BaseField = F>>(
+    keys: &[Affine<P>],
+) -> Vec<CF> {
     keys.iter()
         .flat_map(|p| vec![p.x, p.y])
-        .flat_map(|c| AllocatedNonNativeFieldVar::<F, CF>::get_limbs_representations(&c, OptimizationType::Constraints).unwrap())
+        .flat_map(|c| {
+            AllocatedNonNativeFieldVar::<F, CF>::get_limbs_representations(
+                &c,
+                OptimizationType::Constraints,
+            )
+            .unwrap()
+        })
         .collect()
 }
 
@@ -63,8 +92,8 @@ mod tests {
     use ark_relations::r1cs::ConstraintSystem;
     use ark_snark::SNARK;
     use ark_std::{test_rng, UniformRand};
-    use rand::Rng;
     use rand::rngs::OsRng;
+    use rand::Rng;
 
     use super::*;
 
@@ -72,13 +101,17 @@ mod tests {
     fn apk_foreign() {
         let rng = &mut OsRng;
         let n = 3;
-        let keys: Vec<ark_bls12_381::G1Affine> = (0..n).map(|_| ark_bls12_381::G1Affine::rand(rng)).collect();
+        let keys: Vec<ark_bls12_381::G1Affine> =
+            (0..n).map(|_| ark_bls12_381::G1Affine::rand(rng)).collect();
         let bits: Vec<bool> = (0..n).map(|_| rng.gen_bool(0.9)).collect();
         let seed = ark_bls12_381::G1Affine::rand(rng); // TODO
 
         let cs = ConstraintSystem::<ark_bls12_381::Fr>::new_ref();
         let bit_vars = Vec::<Boolean<ark_bls12_381::Fr>>::new_constant(cs, bits.clone()).unwrap();
-        let packed_bits = Boolean::le_bits_to_fp_var(&bit_vars).unwrap().value().unwrap();
+        let packed_bits = Boolean::le_bits_to_fp_var(&bit_vars)
+            .unwrap()
+            .value()
+            .unwrap();
 
         let circuit = ApkCircuit {
             keys: keys.clone(),
@@ -95,20 +128,26 @@ mod tests {
         let mut pi = keys_to_limbs(&keys);
         pi.push(packed_bits);
         let pi = Groth16::<Bls12_381>::prepare_inputs(&pvk, &pi).unwrap();
-        assert!(Groth16::<Bls12_381>::verify_proof_with_prepared_inputs(&pvk, &proof, &pi).unwrap());
+        assert!(
+            Groth16::<Bls12_381>::verify_proof_with_prepared_inputs(&pvk, &proof, &pi).unwrap()
+        );
     }
 
     #[test]
     fn apk_native() {
         let rng = &mut OsRng;
         let n = 3;
-        let keys: Vec<ark_bls12_377::G1Affine> = (0..n).map(|_| ark_bls12_377::G1Affine::rand(rng)).collect();
+        let keys: Vec<ark_bls12_377::G1Affine> =
+            (0..n).map(|_| ark_bls12_377::G1Affine::rand(rng)).collect();
         let bits: Vec<bool> = (0..n).map(|_| rng.gen_bool(0.9)).collect();
         let seed = ark_bls12_377::G1Affine::rand(rng); // TODO
 
         let cs = ConstraintSystem::<ark_bw6_761::Fr>::new_ref();
         let bit_vars = Vec::<Boolean<ark_bw6_761::Fr>>::new_constant(cs, bits.clone()).unwrap();
-        let packed_bits = Boolean::le_bits_to_fp_var(&bit_vars).unwrap().value().unwrap();
+        let packed_bits = Boolean::le_bits_to_fp_var(&bit_vars)
+            .unwrap()
+            .value()
+            .unwrap();
 
         let circuit = ApkCircuit {
             keys: keys.clone(),
@@ -137,7 +176,10 @@ mod tests {
         let cs = ConstraintSystem::<ark_bls12_381::Fr>::new_ref();
         let bit_vars = Vec::<Boolean<ark_bls12_381::Fr>>::new_constant(cs, bits.clone()).unwrap();
         let bits_packed_var = Boolean::le_bits_to_fp_var(&bit_vars).unwrap();
-        let bits_back: Vec<bool> = bits_packed_var.to_bits_le().unwrap().iter()
+        let bits_back: Vec<bool> = bits_packed_var
+            .to_bits_le()
+            .unwrap()
+            .iter()
             .take(n)
             .map(|b| b.value().unwrap())
             .collect();
@@ -146,7 +188,11 @@ mod tests {
 
     #[test]
     fn test_limbs_foreign() {
-        let limbs: Vec<ark_bls12_381::Fr> = keys_to_limbs(&[ark_bls12_381::G1Affine::rand(&mut test_rng())]);
-        println!("bls12_381::G1Affine is represented with {} limbs in bls12_381::Fr", limbs.len());
+        let limbs: Vec<ark_bls12_381::Fr> =
+            keys_to_limbs(&[ark_bls12_381::G1Affine::rand(&mut test_rng())]);
+        println!(
+            "bls12_381::G1Affine is represented with {} limbs in bls12_381::Fr",
+            limbs.len()
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@ mod affine_gen;
 mod apk_circuits;
 mod sum_acc;
 
+pub use apk_circuits::{keys_to_limbs, ApkCircuit};
+
 #[cfg(test)]
 mod tests {
     use ark_ff::Field;


### PR DESCRIPTION
* adds `AprkCircuits::new` and exposes that and `keys_to_limbs` in the public API
* cargo fmt, taplo fmt
* add apk to the proof and check it